### PR TITLE
refactor: custom adapter can now be passed through initOptions object

### DIFF
--- a/src/keycloak/client.ts
+++ b/src/keycloak/client.ts
@@ -6,8 +6,8 @@ import type { RNKeycloakInitOptions } from './types';
 class KeycloakReactNativeClient extends KeycloakClient {
   public async init(initOptions: RNKeycloakInitOptions): Promise<boolean> {
     return super.init({
-      ...initOptions,
       adapter: RNAdapter,
+      ...initOptions,
     });
   }
 }


### PR DESCRIPTION
## Description
I rearranged the order of the init params spread to allow a custom adapter to be passed through the `initOptions` object. In some advanced cases, a user might want to pass in a custom Keycloak adapter [which is allowed in the Keycloak spec](https://www.keycloak.org/docs/latest/securing_apps/#custom-adapters).

## Type of change

<!--
  Please delete options that are not relevant.
-->

- Feature improvement: enhances an existing feature but doesn't affect existing functionality

## How Has This Been Tested?

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration
-->

- [X] Passed custom adapter to `initOptions` in Example app; succeeded
- [X] Passed custom adapter to `initOptions` in proprietary enterprise app (where this functionality is needed); succeeded

**Test Configuration**:

- Device: iPhone 13 Pro Max (iOS 15.3.1)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

p.s. Sorry for botching the last PR