### PR TITLE
chore: react-native-inappbrowser-reborn update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-keycloak/native",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "license": "MIT",
   "description": "React Native component for Keycloak javascript adapter",
   "repository": "https://github.com/react-keycloak/react-native-keycloak",
@@ -50,7 +50,7 @@
   "dependencies": {
     "@react-keycloak/core": "^3.2.0",
     "@react-keycloak/keycloak-ts": "^0.2.4",
-    "react-native-inappbrowser-reborn": "^3.6.3"
+    "react-native-inappbrowser-reborn": "^3.7.0"
   },
   "peerDependencies": {
     "react": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7402,7 +7402,7 @@ open@^6.2.0:
   dependencies:
     is-wsl "^1.1.0"
 
-opencollective-postinstall@^2.0.2:
+opencollective-postinstall@^2.0.2, opencollective-postinstall@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
   integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
@@ -7946,13 +7946,13 @@ react-is@^16.12.0, react-is@^16.8.1, react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-native-inappbrowser-reborn@^3.6.3:
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/react-native-inappbrowser-reborn/-/react-native-inappbrowser-reborn-3.6.3.tgz#12938733e5337a9f328973557da0cfd13085bfbd"
-  integrity sha512-fqF708GVZ/7zja0/GyJQfjDfKREOe1fxYq8RAKZo8/KK6SkFO9hBlYqC3PwLFPw29zzwBzR+6EpL3qo95igkLw==
+react-native-inappbrowser-reborn@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/react-native-inappbrowser-reborn/-/react-native-inappbrowser-reborn-3.7.0.tgz#849a43c3c7da22b65147649fe596836bcb494083"
+  integrity sha512-Ia53jYNtFcbNaX5W3QfOmN25I7bcvuDiQmSY5zABXjy4+WI20bPc9ua09li55F8yDCjv3C99jX6vKms68mBV7g==
   dependencies:
     invariant "^2.2.4"
-    opencollective-postinstall "^2.0.2"
+    opencollective-postinstall "^2.0.3"
 
 react-native@0.62.2:
   version "0.62.2"


### PR DESCRIPTION
## Description
In this package we have `react-native-inappbrowser-reborn` as one of dependencies.
The current version has a android permission inside the AndroidManifest.xml: 
<uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
More about the permission: [Link here](https://support.google.com/googleplay/android-developer/answer/10158779?hl=en)

This is a specific permission and Google has been blocking all new deploys that use this permission. The inappbrowser is already update, so we need to update our package as well

Fixes # (issue)
Update **react-native-inappbrowser-reborn** to the current and stable version 3.7.0

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
In this branch, run `yarn `or `npm i`
Publish lib in local, using `yalc publish`
On one project that use the package, install using `yalc add @react-keycloak/native@0.6.3`
Run on Android and iOS
After test, remove the package from yalc: `yalc remove @react-keycloak/native@0.6.3`

**Test Configuration**:

- Device: iPhone 13 (iOS 15.5)

![Kapture 2022-09-15 at 10 26 53](https://user-images.githubusercontent.com/57924169/190415996-d5065e2b-9316-4d08-92ed-ac7e9f967060.gif)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
